### PR TITLE
Add parseFloat to quantity

### DIFF
--- a/DynamicYieldKit.js
+++ b/DynamicYieldKit.js
@@ -168,8 +168,8 @@
             return productList.map(function(product) {
                 var attrs = {
                     productId: product.Sku,
-                    quantity: parseFloat(product.Quantity),
-                    itemPrice: parseFloat(product.Price)
+                    quantity: Number(product.Quantity),
+                    itemPrice: Number(product.Price)
                 };
                 for (var key in product.Attributes) {
                     if (!ignoredKeys[key]) {
@@ -195,7 +195,7 @@
                     dyType: 'add-to-cart-v1',
                     value: product.quantity * product.itemPrice,
                     productId: product.productId,
-                    quantity: parseFloat(product.quantity)
+                    quantity: Number(product.quantity)
                 };
                 if (event.CurrencyCode) {
                     properties.currency = event.CurrencyCode;
@@ -309,7 +309,7 @@
                 dyType: 'remove-from-cart-v1',
                 value: removedProduct.Quantity * removedProduct.Price,
                 productId: removedProduct.Sku,
-                quantity: parseFloat(removedProduct.Quantity),
+                quantity: Number(removedProduct.Quantity),
                 cart: mapMPProductListToDYCart(event.ShoppingCart.ProductList).filter(function(product) {
                     return product.productId !== removedProduct.Sku;
                 })

--- a/DynamicYieldKit.js
+++ b/DynamicYieldKit.js
@@ -168,8 +168,8 @@
             return productList.map(function(product) {
                 var attrs = {
                     productId: product.Sku,
-                    quantity: product.Quantity,
-                    itemPrice: product.Price
+                    quantity: parseFloat(product.Quantity),
+                    itemPrice: parseFloat(product.Price)
                 };
                 for (var key in product.Attributes) {
                     if (!ignoredKeys[key]) {
@@ -195,7 +195,7 @@
                     dyType: 'add-to-cart-v1',
                     value: product.quantity * product.itemPrice,
                     productId: product.productId,
-                    quantity: product.quantity
+                    quantity: parseFloat(product.quantity)
                 };
                 if (event.CurrencyCode) {
                     properties.currency = event.CurrencyCode;
@@ -309,7 +309,7 @@
                 dyType: 'remove-from-cart-v1',
                 value: removedProduct.Quantity * removedProduct.Price,
                 productId: removedProduct.Sku,
-                quantity: removedProduct.Quantity,
+                quantity: parseFloat(removedProduct.Quantity),
                 cart: mapMPProductListToDYCart(event.ShoppingCart.ProductList).filter(function(product) {
                     return product.productId !== removedProduct.Sku;
                 })

--- a/test/tests.js
+++ b/test/tests.js
@@ -228,7 +228,7 @@ describe('ClientSdk Forwarder', function () {
                         Price: 50,
                         Name: 'Prod1',
                         TotalAmount: 50,
-                        Quantity: 1,
+                        Quantity: '1',
                         Attributes: {attribute2: 'test2'},
                         Sku: 'Sku2'
                     }
@@ -253,6 +253,7 @@ describe('ClientSdk Forwarder', function () {
         window.DY.properties.currency.should.equal('USD');
         window.DY.properties.productId.should.equal('Sku2');
         window.DY.properties.quantity.should.equal(1);
+        (typeof window.DY.properties.quantity).should.equal('number');
         window.DY.properties.attribute2.should.equal('test2');
         window.DY.properties.cart[0].productId.should.equal('Sku1');
         window.DY.properties.cart[0].quantity.should.equal(2);
@@ -352,7 +353,7 @@ describe('ClientSdk Forwarder', function () {
                         Price: 100,
                         Name: 'OldProd1',
                         TotalAmount: 200,
-                        Quantity: 2,
+                        Quantity: '2',
                         Attributes: {attribute1: 'test1'},
                         Sku: 'Sku1'
                     }
@@ -385,6 +386,7 @@ describe('ClientSdk Forwarder', function () {
         window.DY.properties.currency.should.equal('USD');
         window.DY.properties.productId.should.equal('Sku1');
         window.DY.properties.quantity.should.equal(2);
+        (typeof (window.DY.properties.quantity)).should.equal('number');
         window.DY.properties.attribute1.should.equal('test1');
         window.DY.properties.cart.length.should.equal(1);
         window.DY.properties.cart[0].productId.should.equal('Sku2');


### PR DESCRIPTION
DynamicYield requires quantity/value to be numbers and not strings. While this isn't an issue when a customer directly call mParticle.eCommerce.Cart.add(mParticle.createProduct('name', 'sku', 123, 1))... with quantity/price as numbers, for some reason when implementing us via GTM, GTM's data layer converts numbers to strings.

This is a quick fix to force quantity to be sent as to DynamicYield as a Number.