### PR TITLE
refactor: Remove isobject dependency for inline function

### DIFF
--- a/src/DynamicYieldKit.js
+++ b/src/DynamicYieldKit.js
@@ -14,8 +14,6 @@
 //  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
-var isobject = require('isobject');
-
 var name = 'DynamicYield',
     moduleId = 128,
     MessageType = {
@@ -401,6 +399,12 @@ function getId() {
     return moduleId;
 }
 
+function isObject(val) {
+    return (
+        val != null && typeof val === 'object' && Array.isArray(val) === false
+    );
+}
+
 function register(config) {
     if (!config) {
         console.log(
@@ -409,14 +413,14 @@ function register(config) {
         return;
     }
 
-    if (!isobject(config)) {
+    if (!isObject(config)) {
         console.log(
             "'config' must be an object. You passed in a " + typeof config
         );
         return;
     }
 
-    if (isobject(config.kits)) {
+    if (isObject(config.kits)) {
         config.kits[name] = {
             constructor: constructor,
         };


### PR DESCRIPTION
We have removed this dependency from other kits as it is a simple function. Removing it from DY as well.  See [GA](https://github.com/mparticle-integrations/mparticle-javascript-integration-google-analytics/blob/master/src/GoogleAnalyticsEventForwarder.js#L706-L708) as an example.