### PR TITLE
Fix/add identity to event queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# integration-dyanamic-yield
+# integration-dynamic-yield
 
 Dynamic Yield Javascript integration for mParticle
 
 #License
 
-Copyright 2018 mParticle, Inc.
+Copyright 2021 mParticle, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/DynamicYieldKit.js
+++ b/src/DynamicYieldKit.js
@@ -31,7 +31,8 @@ var constructor = function() {
         isInitialized = false,
         reportingService,
         settings,
-        eventQueue = [];
+        eventQueue = [],
+        identityQueue = [];
 
     self.name = name;
 
@@ -70,6 +71,14 @@ var constructor = function() {
                     ).appendChild(DYStatic);
                     DYStatic.onload = function() {
                         isInitialized = true;
+
+                        if (DY && DY.API && identityQueue.length > 0) {
+                            for (var i = 0; i < identityQueue.length; i++) {
+                                onUserIdentified(identityQueue[i]);
+                            }
+
+                            eventQueue = [];
+                        }
 
                         if (DY && DY.API && eventQueue.length > 0) {
                             for (var i = 0; i < eventQueue.length; i++) {
@@ -249,6 +258,10 @@ var constructor = function() {
     }
 
     function onUserIdentified(mpUser) {
+        if (!isInitialized) {
+            identityQueue.push(mpUser);
+            return;
+        }
         var properties = { dyType: 'login-v1' },
             userIdentities = mpUser.getUserIdentities().userIdentities;
 

--- a/test/index.html
+++ b/test/index.html
@@ -9,7 +9,6 @@
 
     <script src="../node_modules/mocha/mocha.js"></script>
     <script src="../node_modules/should/should.js"></script>
-    <script src="../node_modules/blanket/dist/mocha/blanket_mocha.js"></script>
 
     <script>
         var mp = function () {

--- a/test/tests.js
+++ b/test/tests.js
@@ -376,7 +376,7 @@ describe('ClientSdk Forwarder', function() {
                     ProductList: [oldProduct],
                 },
             });
-            debugger;
+
             window.DY.dyType[0].should.equal('add-to-cart-v1');
             window.DY.addToCartIterations.should.equal(3);
             // each property is added
@@ -483,7 +483,6 @@ describe('ClientSdk Forwarder', function() {
         });
 
         it('should log a custom event', function(done) {
-            debugger;
             mParticle.forwarder.process({
                 EventName: 'custom event',
                 EventDataType: MessageType.PageEvent,
@@ -493,7 +492,7 @@ describe('ClientSdk Forwarder', function() {
                     foo2: 'bar2',
                 },
             });
-            debugger;
+
             window.DY.name.should.equal('custom event');
             window.DY.properties[0].foo1.should.equal('bar1');
             window.DY.properties[0].foo2.should.equal('bar2');

--- a/test/tests.js
+++ b/test/tests.js
@@ -1,11 +1,13 @@
 /* eslint-disable no-undef*/
-describe('ClientSdk Forwarder', function () {
+describe('ClientSdk Forwarder', function() {
     var expandCommerceEvent = function(event) {
-            return [{
-                EventName: event.EventName,
-                EventDataType: event.EventDataType,
-                EventAttributes: event.EventAttributes
-            }];
+            return [
+                {
+                    EventName: event.EventName,
+                    EventDataType: event.EventDataType,
+                    EventAttributes: event.EventAttributes,
+                },
+            ];
         },
         MessageType = {
             SessionStart: 1,
@@ -14,7 +16,7 @@ describe('ClientSdk Forwarder', function () {
             PageEvent: 4,
             CrashReport: 5,
             OptOut: 6,
-            Commerce: 16
+            Commerce: 16,
         },
         EventType = {
             Unknown: 0,
@@ -28,9 +30,9 @@ describe('ClientSdk Forwarder', function () {
             Other: 8,
             Media: 9,
             ProductPurchase: 16,
-            getName: function () {
+            getName: function() {
                 return 'blahblah';
-            }
+            },
         },
         CommerceEventType = {
             ProductAddToCart: 10,
@@ -45,7 +47,7 @@ describe('ClientSdk Forwarder', function () {
             PromotionClick: 19,
             ProductAddToWishlist: 20,
             ProductRemoveFromWishlist: 21,
-            ProductImpression: 22
+            ProductImpression: 22,
         },
         ProductActionType = {
             Unknown: 0,
@@ -58,7 +60,7 @@ describe('ClientSdk Forwarder', function () {
             Purchase: 7,
             Refund: 8,
             AddToWishlist: 9,
-            RemoveFromWishlist: 10
+            RemoveFromWishlist: 10,
         },
         IdentityType = {
             Other: 0,
@@ -71,398 +73,474 @@ describe('ClientSdk Forwarder', function () {
             Email: 7,
             Alias: 8,
             FacebookCustomAudienceId: 9,
-            getName: function () {return 'CustomerID';}
+            getName: function() {
+                return 'CustomerID';
+            },
         },
         PromotionActionType = {
             Unknown: 0,
             PromotionView: 1,
-            PromotionClick: 2
+            PromotionClick: 2,
         },
-        ReportingService = function () {
+        ReportingService = function() {
             var self = this;
 
             this.id = null;
             this.event = null;
 
-            this.cb = function (forwarder, event) {
+            this.cb = function(forwarder, event) {
                 self.id = forwarder.id;
                 self.event = event;
             };
 
-            this.reset = function () {
+            this.reset = function() {
                 this.id = null;
                 this.event = null;
             };
         },
         reportService = new ReportingService(),
-
         MockDynamicYieldSdk = function() {
             var self = this;
             self.addToCartIterations = 0;
+            self.dyType = [];
+            self.properties = [];
             this.API = function(eventType, data) {
                 if (data.name === 'Purchase') {
-                    self.dyType = 'purchase-v1';
-                    self.properties = data.properties;
-                }
-                else if (data.name === 'Add to Cart') {
+                    self.dyType.push('purchase-v1');
+                    self.properties.push(data.properties);
+                } else if (data.name === 'Add to Cart') {
                     self.addToCartIterations++;
-                    self.dyType = 'add-to-cart-v1';
-                    self.properties = data.properties;
-                }
-                else if (data.name === 'Add to Wishlist') {
-                    self.dyType = 'add-to-wishlist-v1';
-                    self.properties = data.properties;
-                }
-                else if (data.name === 'Remove from Cart') {
-                    self.dyType = 'remove-from-cart-v1';
-                    self.properties = data.properties;
-                }
-                else if (data.name === 'Keyword Search') {
-                    self.dyType = 'keyword-search-v1';
-                    self.properties = data.properties;
-                }
-                else if (data.name === 'Login') {
-                    self.dyType = 'login-v1';
-                    self.properties = data.properties;
+                    self.dyType.push('add-to-cart-v1');
+                    self.properties.push(data.properties);
+                } else if (data.name === 'Add to Wishlist') {
+                    self.dyType.push('add-to-wishlist-v1');
+                    self.properties.push(data.properties);
+                } else if (data.name === 'Remove from Cart') {
+                    self.dyType.push('remove-from-cart-v1');
+                    self.properties.push(data.properties);
+                } else if (data.name === 'Keyword Search') {
+                    self.dyType.push('keyword-search-v1');
+                    self.properties.push(data.properties);
+                } else if (data.name === 'Login') {
+                    self.dyType.push('login-v1');
+                    self.properties.push(data.properties);
                     self.loginCalled = true;
                 }
                 // custom event
                 else {
                     self.name = data.name;
-                    self.properties = data.properties;
+                    self.properties.push(data.properties);
                 }
             };
 
             this.loginCalled = false;
         };
-
-    before(function () {
-        mParticle.EventType = EventType;
-        mParticle.ProductActionType = ProductActionType;
-        mParticle.PromotionType = PromotionActionType;
-        mParticle.IdentityType = IdentityType;
-        mParticle.CommerceEventType = CommerceEventType;
-        mParticle.eCommerce = {};
-        mParticle.eCommerce.expandCommerceEvent = expandCommerceEvent;
-    });
-
-    beforeEach(function() {
-        window.DY = new MockDynamicYieldSdk();
-        mParticle.forwarder.init({
-            apiKey: '123456'
-        }, reportService.cb, true, null, {
-            userAttr1: 'value1',
-            userAttr2: 'value2'
-        }, [{
-            Identity: 'customerId',
-            Type: IdentityType.CustomerId
-        }, {
-            Identity: 'email@emailco.com',
-            Type: IdentityType.Email
-        }, {
-            Identity: 'facebookId',
-            Type: IdentityType.Facebook
-        }], '1.1', 'My App');
-    });
-
-
-    it('should log a purchase event', function(done){
-        mParticle.forwarder.process({
-            EventName: 'Test Purchase Event',
-            EventDataType: MessageType.Commerce,
-            EventCategory: EventType.ProductPurchase,
-            EventAttributes: {
-                key1: 'value1',
-                key2: 'value2'
-            },
-            CurrencyCode: 'USD',
-            ProductAction: {
-                TransactionId: '1234',
-                TotalAmount: 150,
-                ProductList: [
-                    {
-                        Price: 50,
-                        Name: 'Prod1',
-                        TotalAmount: 50,
-                        Quantity: 1,
-                        Attributes: {attribute1: 'test'},
-                        Sku: '12345'
-                    },
-                    {
-                        Price: 100,
-                        Name: 'Prod2',
-                        TotalAmount: 100,
-                        Quantity: 1,
-                        Attributes: {attribute2: 'test2'},
-                        Sku: '23456'
-                    }
-                ]
-            }
+    describe('not initialized', function() {
+        before(function() {
+            mParticle.EventType = EventType;
+            mParticle.ProductActionType = ProductActionType;
+            mParticle.PromotionType = PromotionActionType;
+            mParticle.IdentityType = IdentityType;
+            mParticle.CommerceEventType = CommerceEventType;
+            mParticle.eCommerce = {};
+            mParticle.eCommerce.expandCommerceEvent = expandCommerceEvent;
         });
 
-        window.DY.dyType.should.equal('purchase-v1');
-        window.DY.properties.uniqueTransactionId.should.equal('1234');
-        window.DY.properties.value.should.equal(150);
-        window.DY.properties.currency.should.equal('USD');
-        window.DY.properties.key1.should.equal('value1');
-        window.DY.properties.key2.should.equal('value2');
+        it('should not queue events and identities, and process them when initialized', function() {
+            window.DY = new MockDynamicYieldSdk();
 
-        done();
-    });
+            mParticle.forwarder.process({
+                EventName: 'custom event',
+                EventDataType: MessageType.PageEvent,
+                EventCategory: EventType.Navigation,
+                EventAttributes: {
+                    foo1: 'bar1',
+                    foo2: 'bar2',
+                },
+            });
 
-    it('should log an addToCart event', function(done){
-        mParticle.forwarder.process({
-            EventName: 'eCommerce - AddToCart',
-            EventDataType: MessageType.Commerce,
-            EventCategory: CommerceEventType.ProductAddToCart,
-            CurrencyCode: 'USD',
-            ProductAction: {
-                ProductList: [
-                    {
-                        Price: 50,
-                        Name: 'Prod1',
-                        TotalAmount: 50,
-                        Quantity: '1',
-                        Attributes: {attribute2: 'test2'},
-                        Sku: 'Sku2'
-                    }
-                ]
-            },
-            ShoppingCart: {
-                ProductList: [
-                    {
-                        Price: 100,
-                        Name: 'OldProd1',
-                        TotalAmount: 200,
-                        Quantity: 2,
-                        Attributes: {attribute1: 'test1'},
-                        Sku: 'Sku1'
-                    }
-                ]
-            }
-        });
-
-        window.DY.dyType.should.equal('add-to-cart-v1');
-        window.DY.properties.value.should.equal(50);
-        window.DY.properties.currency.should.equal('USD');
-        window.DY.properties.productId.should.equal('Sku2');
-        window.DY.properties.quantity.should.equal(1);
-        (typeof window.DY.properties.quantity).should.equal('number');
-        window.DY.properties.attribute2.should.equal('test2');
-
-        done();
-    });
-
-    it('should log addToCart events properly if more than 1 unique product is added', function(done){
-        var product1 = {
-                Price: 50,
-                Name: 'Prod1',
-                TotalAmount: 50,
-                Quantity: 1,
-                Attributes: {attribute1: 'test1'},
-                Sku: 'Sku1'
-            },
-            product2 = {
-                Price: 150,
-                Name: 'Prod2',
-                TotalAmount: 150,
-                Quantity: 2,
-                Attributes: {attribute2: 'test2'},
-                Sku: 'Sku2'
-            },
-            product3 = {
-                Price: 250,
-                Name: 'Prod3',
-                TotalAmount: 250,
-                Quantity: 3,
-                Attributes: {attribute3: 'test3'},
-                Sku: 'Sku3'
-            },
-            oldProduct = {
-                Price: 100,
-                Name: 'OldProd1',
-                TotalAmount: 400,
-                Quantity: 4,
-                Attributes: {attribute1: 'test'},
-                Sku: 'OldProdSku1'
+            var mpUser = {
+                getUserIdentities: function() {
+                    return {
+                        userIdentities: { customerid: 'abc' },
+                    };
+                },
             };
+            mParticle.forwarder.onUserIdentified(mpUser);
 
-        mParticle.forwarder.process({
-            EventName: 'eCommerce - AddToCart',
-            EventDataType: MessageType.Commerce,
-            EventCategory: CommerceEventType.ProductAddToCart,
-            CurrencyCode: 'USD',
-            ProductAction: {
-                ProductList: [product1, product2, product3]
-            },
-            ShoppingCart: {
-                ProductList: [oldProduct]
-            }
-        });
-
-        window.DY.dyType.should.equal('add-to-cart-v1');
-        window.DY.addToCartIterations.should.equal(3);
-        window.DY.properties.value.should.equal(product3.Quantity * product3.Price);
-        window.DY.properties.currency.should.equal('USD');
-        window.DY.properties.productId.should.equal(product3.Sku);
-        window.DY.properties.quantity.should.equal(product3.Quantity);
-        window.DY.properties.attribute3.should.equal('test3');
-
-        done();
-    });
-
-    it('should log a removeFromCart event', function(done){
-        mParticle.forwarder.process({
-            EventName: 'eCommerce - RemoveFromCart',
-            EventDataType: MessageType.Commerce,
-            EventCategory: CommerceEventType.ProductRemoveFromCart,
-            CurrencyCode: 'USD',
-            ProductAction: {
-                ProductList: [
+            window.DY.dyType.length.should.equal(0);
+            mParticle.forwarder.init(
+                {
+                    apiKey: '123456',
+                },
+                reportService.cb,
+                true,
+                null,
+                {
+                    userAttr1: 'value1',
+                    userAttr2: 'value2',
+                },
+                [
                     {
-                        Price: 100,
-                        Name: 'OldProd1',
-                        TotalAmount: 200,
-                        Quantity: '2',
-                        Attributes: {attribute1: 'test1'},
-                        Sku: 'Sku1'
-                    }
-                ]
-            },
-            ShoppingCart: {
-                ProductList: [
-                    {
-                        Price: 100,
-                        Name: 'OldProd1',
-                        TotalAmount: 200,
-                        Quantity: 2,
-                        Attributes: {attribute1: 'test1'},
-                        Sku: 'Sku1'
+                        Identity: 'customerId',
+                        Type: IdentityType.CustomerId,
                     },
                     {
-                        Price: 30,
-                        Name: 'OldProd2',
-                        TotalAmount: 200,
-                        Quantity: 1,
-                        Attributes: {attribute2: 'test2'},
-                        Sku: 'Sku2'
-                    }
-                ]
-            }
-        });
-
-        window.DY.dyType.should.equal('remove-from-cart-v1');
-        window.DY.properties.value.should.equal(200);
-        window.DY.properties.currency.should.equal('USD');
-        window.DY.properties.productId.should.equal('Sku1');
-        window.DY.properties.quantity.should.equal(2);
-        (typeof (window.DY.properties.quantity)).should.equal('number');
-        window.DY.properties.attribute1.should.equal('test1');
-
-        done();
-    });
-
-    it('should log an addToWishlist event', function(done){
-        mParticle.forwarder.process({
-            EventName: 'eCommerce - AddToWishlist',
-            EventDataType: MessageType.Commerce,
-            EventCategory: CommerceEventType.ProductAddToWishlist,
-            CurrencyCode: 'USD',
-            ProductAction: {
-                ProductList: [
+                        Identity: 'email@emailco.com',
+                        Type: IdentityType.Email,
+                    },
                     {
-                        Price: 50,
-                        Name: 'Prod1',
-                        TotalAmount: 50,
-                        Quantity: 1,
-                        Attributes: {attribute1: 'test'},
-                        Sku: 'Sku2'
-                    }
-                ]
-            }
+                        Identity: 'facebookId',
+                        Type: IdentityType.Facebook,
+                    },
+                ],
+                '1.1',
+                'My App'
+            );
         });
-
-        window.DY.dyType.should.equal('add-to-wishlist-v1');
-        window.DY.properties.productId.should.equal('Sku2');
-        window.DY.properties.attribute1.should.equal('test');
-
-        done();
     });
 
-    it('should log an search event', function(done){
-        mParticle.forwarder.process({
-            EventName: 'test search',
-            EventDataType: MessageType.PageEvent,
-            EventCategory: EventType.Search,
-            CurrencyCode: 'USD',
-            EventAttributes: {
-                Keywords: 'search query',
-                attribute1: 'test1'
-            }
+    describe('initialized', function() {
+        before(function() {
+            mParticle.EventType = EventType;
+            mParticle.ProductActionType = ProductActionType;
+            mParticle.PromotionType = PromotionActionType;
+            mParticle.IdentityType = IdentityType;
+            mParticle.CommerceEventType = CommerceEventType;
+            mParticle.eCommerce = {};
+            mParticle.eCommerce.expandCommerceEvent = expandCommerceEvent;
         });
 
-        window.DY.dyType.should.equal('keyword-search-v1');
-        window.DY.properties.Keywords.should.equal('search query');
-        window.DY.properties.attribute1.should.equal('test1');
-
-        done();
-    });
-
-    it('should log a custom event', function(done){
-        mParticle.forwarder.process({
-            EventName: 'custom event',
-            EventDataType: MessageType.PageEvent,
-            EventCategory: EventType.Navigation,
-            EventAttributes: {
-                foo1: 'bar1',
-                foo2: 'bar2'
-            }
+        beforeEach(function() {
+            window.DY = new MockDynamicYieldSdk();
+            mParticle.forwarder.init(
+                {
+                    apiKey: '123456',
+                },
+                reportService.cb,
+                true,
+                null,
+                {
+                    userAttr1: 'value1',
+                    userAttr2: 'value2',
+                },
+                [
+                    {
+                        Identity: 'customerId',
+                        Type: IdentityType.CustomerId,
+                    },
+                    {
+                        Identity: 'email@emailco.com',
+                        Type: IdentityType.Email,
+                    },
+                    {
+                        Identity: 'facebookId',
+                        Type: IdentityType.Facebook,
+                    },
+                ],
+                '1.1',
+                'My App'
+            );
         });
 
-        window.DY.name.should.equal('custom event');
-        window.DY.properties.foo1.should.equal('bar1');
-        window.DY.properties.foo2.should.equal('bar2');
+        it('should log a purchase event', function(done) {
+            mParticle.forwarder.process({
+                EventName: 'Test Purchase Event',
+                EventDataType: MessageType.Commerce,
+                EventCategory: EventType.ProductPurchase,
+                EventAttributes: {
+                    key1: 'value1',
+                    key2: 'value2',
+                },
+                CurrencyCode: 'USD',
+                ProductAction: {
+                    TransactionId: '1234',
+                    TotalAmount: 150,
+                    ProductList: [
+                        {
+                            Price: 50,
+                            Name: 'Prod1',
+                            TotalAmount: 50,
+                            Quantity: 1,
+                            Attributes: { attribute1: 'test' },
+                            Sku: '12345',
+                        },
+                        {
+                            Price: 100,
+                            Name: 'Prod2',
+                            TotalAmount: 100,
+                            Quantity: 1,
+                            Attributes: { attribute2: 'test2' },
+                            Sku: '23456',
+                        },
+                    ],
+                },
+            });
 
-        done();
-    });
-
-    it('should successfully log in with customer id and hashed email', function(done){
-        var mParticleUser = {
-            getUserIdentities: function() {
-                return {
-                    userIdentities: {
-                        customerid: 'testid',
-                        email: 'TEST@gmail.com'
-                    }
-                };
-            }
-        };
-
-        mParticle.forwarder.onUserIdentified(mParticleUser);
-
-        // due to promise from hashing an email, we setTimeout so promise is resolved before testing
-        setTimeout(function() {
-            window.DY.properties.dyType.should.equal('login-v1');
-            window.DY.properties.cuid.should.equal('testid');
-            window.DY.properties.cuidType.should.equal('customerid');
-            window.DY.properties.hashedEmail.should.equal('87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674');
-            window.DY.properties.cuidType.should.equal('customerid');
+            window.DY.dyType[0].should.equal('purchase-v1');
+            window.DY.properties[0].uniqueTransactionId.should.equal('1234');
+            window.DY.properties[0].value.should.equal(150);
+            window.DY.properties[0].currency.should.equal('USD');
+            window.DY.properties[0].key1.should.equal('value1');
+            window.DY.properties[0].key2.should.equal('value2');
 
             done();
-        }, 10);
-    });
+        });
 
-    it('should not call log in if there is no customer id or email', function(done){
-        var mParticleUser = {
-            getUserIdentities: function() {
-                return {userIdentities: {}};
-            }
-        };
+        it('should log an addToCart event', function(done) {
+            mParticle.forwarder.process({
+                EventName: 'eCommerce - AddToCart',
+                EventDataType: MessageType.Commerce,
+                EventCategory: CommerceEventType.ProductAddToCart,
+                CurrencyCode: 'USD',
+                ProductAction: {
+                    ProductList: [
+                        {
+                            Price: 50,
+                            Name: 'Prod1',
+                            TotalAmount: 50,
+                            Quantity: '1',
+                            Attributes: { attribute2: 'test2' },
+                            Sku: 'Sku2',
+                        },
+                    ],
+                },
+                ShoppingCart: {
+                    ProductList: [
+                        {
+                            Price: 100,
+                            Name: 'OldProd1',
+                            TotalAmount: 200,
+                            Quantity: 2,
+                            Attributes: { attribute1: 'test1' },
+                            Sku: 'Sku1',
+                        },
+                    ],
+                },
+            });
 
-        mParticle.forwarder.onUserIdentified(mParticleUser);
+            window.DY.dyType[0].should.equal('add-to-cart-v1');
+            window.DY.properties[0].value.should.equal(50);
+            window.DY.properties[0].currency.should.equal('USD');
+            window.DY.properties[0].productId.should.equal('Sku2');
+            window.DY.properties[0].quantity.should.equal(1);
+            (typeof window.DY.properties[0].quantity).should.equal('number');
+            window.DY.properties[0].attribute2.should.equal('test2');
 
-        window.DY.loginCalled.should.equal(false);
+            done();
+        });
 
-        done();
+        it('should log addToCart events properly if more than 1 unique product is added', function(done) {
+            var product1 = {
+                    Price: 50,
+                    Name: 'Prod1',
+                    TotalAmount: 50,
+                    Quantity: 1,
+                    Attributes: { attribute1: 'test1' },
+                    Sku: 'Sku1',
+                },
+                product2 = {
+                    Price: 150,
+                    Name: 'Prod2',
+                    TotalAmount: 150,
+                    Quantity: 2,
+                    Attributes: { attribute2: 'test2' },
+                    Sku: 'Sku2',
+                },
+                product3 = {
+                    Price: 250,
+                    Name: 'Prod3',
+                    TotalAmount: 250,
+                    Quantity: 3,
+                    Attributes: { attribute3: 'test3' },
+                    Sku: 'Sku3',
+                },
+                oldProduct = {
+                    Price: 100,
+                    Name: 'OldProd1',
+                    TotalAmount: 400,
+                    Quantity: 4,
+                    Attributes: { attribute1: 'test' },
+                    Sku: 'OldProdSku1',
+                };
+
+            mParticle.forwarder.process({
+                EventName: 'eCommerce - AddToCart',
+                EventDataType: MessageType.Commerce,
+                EventCategory: CommerceEventType.ProductAddToCart,
+                CurrencyCode: 'USD',
+                ProductAction: {
+                    ProductList: [product1, product2, product3],
+                },
+                ShoppingCart: {
+                    ProductList: [oldProduct],
+                },
+            });
+            debugger;
+            window.DY.dyType[0].should.equal('add-to-cart-v1');
+            window.DY.addToCartIterations.should.equal(3);
+            // each property is added
+            window.DY.properties[0].value.should.equal(
+                product1.Quantity * product1.Price
+            );
+            window.DY.properties[1].value.should.equal(
+                product2.Quantity * product2.Price
+            );
+            window.DY.properties[2].value.should.equal(
+                product3.Quantity * product3.Price
+            );
+            window.DY.properties[0].currency.should.equal('USD');
+            window.DY.properties[1].currency.should.equal('USD');
+            window.DY.properties[2].currency.should.equal('USD');
+            window.DY.properties[0].productId.should.equal(product1.Sku);
+            window.DY.properties[1].productId.should.equal(product2.Sku);
+            window.DY.properties[2].productId.should.equal(product3.Sku);
+            window.DY.properties[0].quantity.should.equal(product1.Quantity);
+            window.DY.properties[1].quantity.should.equal(product2.Quantity);
+            window.DY.properties[2].quantity.should.equal(product3.Quantity);
+            window.DY.properties[0].attribute1.should.equal('test1');
+            window.DY.properties[1].attribute2.should.equal('test2');
+            window.DY.properties[2].attribute3.should.equal('test3');
+
+            done();
+        });
+
+        it('should log a removeFromCart event', function(done) {
+            mParticle.forwarder.process({
+                EventName: 'eCommerce - RemoveFromCart',
+                EventDataType: MessageType.Commerce,
+                EventCategory: CommerceEventType.ProductRemoveFromCart,
+                CurrencyCode: 'USD',
+                ProductAction: {
+                    ProductList: [
+                        {
+                            Price: 100,
+                            Name: 'OldProd1',
+                            TotalAmount: 200,
+                            Quantity: '2',
+                            Attributes: { attribute1: 'test1' },
+                            Sku: 'Sku1',
+                        },
+                    ],
+                },
+            });
+
+            window.DY.dyType[0].should.equal('remove-from-cart-v1');
+            window.DY.properties[0].value.should.equal(200);
+            window.DY.properties[0].currency.should.equal('USD');
+            window.DY.properties[0].productId.should.equal('Sku1');
+            window.DY.properties[0].quantity.should.equal(2);
+            (typeof window.DY.properties[0].quantity).should.equal('number');
+            window.DY.properties[0].attribute1.should.equal('test1');
+
+            done();
+        });
+
+        it('should log an addToWishlist event', function(done) {
+            mParticle.forwarder.process({
+                EventName: 'eCommerce - AddToWishlist',
+                EventDataType: MessageType.Commerce,
+                EventCategory: CommerceEventType.ProductAddToWishlist,
+                CurrencyCode: 'USD',
+                ProductAction: {
+                    ProductList: [
+                        {
+                            Price: 50,
+                            Name: 'Prod1',
+                            TotalAmount: 50,
+                            Quantity: 1,
+                            Attributes: { attribute1: 'test' },
+                            Sku: 'Sku2',
+                        },
+                    ],
+                },
+            });
+
+            window.DY.dyType[0].should.equal('add-to-wishlist-v1');
+            window.DY.properties[0].productId.should.equal('Sku2');
+            window.DY.properties[0].attribute1.should.equal('test');
+
+            done();
+        });
+
+        it('should log an search event', function(done) {
+            mParticle.forwarder.process({
+                EventName: 'test search',
+                EventDataType: MessageType.PageEvent,
+                EventCategory: EventType.Search,
+                CurrencyCode: 'USD',
+                EventAttributes: {
+                    Keywords: 'search query',
+                    attribute1: 'test1',
+                },
+            });
+
+            window.DY.dyType[0].should.equal('keyword-search-v1');
+            window.DY.properties[0].Keywords.should.equal('search query');
+            window.DY.properties[0].attribute1.should.equal('test1');
+
+            done();
+        });
+
+        it('should log a custom event', function(done) {
+            debugger;
+            mParticle.forwarder.process({
+                EventName: 'custom event',
+                EventDataType: MessageType.PageEvent,
+                EventCategory: EventType.Navigation,
+                EventAttributes: {
+                    foo1: 'bar1',
+                    foo2: 'bar2',
+                },
+            });
+            debugger;
+            window.DY.name.should.equal('custom event');
+            window.DY.properties[0].foo1.should.equal('bar1');
+            window.DY.properties[0].foo2.should.equal('bar2');
+
+            done();
+        });
+
+        it('should successfully log in with customer id and hashed email', function(done) {
+            var mParticleUser = {
+                getUserIdentities: function() {
+                    return {
+                        userIdentities: {
+                            customerid: 'testid',
+                            email: 'TEST@gmail.com',
+                        },
+                    };
+                },
+            };
+
+            mParticle.forwarder.onUserIdentified(mParticleUser);
+
+            // due to promise from hashing an email, we setTimeout so promise is resolved before testing
+            setTimeout(function() {
+                window.DY.properties[0].dyType.should.equal('login-v1');
+                window.DY.properties[0].cuid.should.equal('testid');
+                window.DY.properties[0].cuidType.should.equal('customerid');
+                window.DY.properties[0].hashedEmail.should.equal(
+                    '87924606b4131a8aceeeae8868531fbb9712aaa07a5d3a756b26ce0f5d6ca674'
+                );
+                window.DY.properties[0].cuidType.should.equal('customerid');
+
+                done();
+            }, 10);
+        });
+
+        it('should not call log in if there is no customer id or email', function(done) {
+            var mParticleUser = {
+                getUserIdentities: function() {
+                    return { userIdentities: {} };
+                },
+            };
+
+            mParticle.forwarder.onUserIdentified(mParticleUser);
+
+            window.DY.loginCalled.should.equal(false);
+
+            done();
+        });
     });
 });


### PR DESCRIPTION
Previously, only regular events got queued if the forwarder wasn't initialized yet. identity requests from core sdk did not get queued if the forwarder was not yet initialized fully. This PR solves this by allowing both regular events and user identity events to be queued.  Since the queue previously only contained regular events, `processEvent` was performed on each queue item.  Identity events require the use of `onUserIdentitifed`, and so we queue each item in a new structure:
```
// an item in the queue schema
{ 
   action: processEvent or onUserIdentified function,
   data: the regular event or the user
} 
```
Now, we can generically call `item.action(item.data)` in order to process ALL items in the queue regardless of if they are an event or a user.

---
TESTS:
The structure of the tests had to be updated in order to make testing for this work properly.  

Previously tests were mostly single events, so we simply replaced the previous event properties that were tested.  If we tried to test 2 events in the same test, the second event would replace the first event andd the 1st event is lost and can't be tested.  Rather than replacing the event, all events get pushed into arrays so that each item can be tested individually.  This was necessary because I am queueing an event and an identity event, and we need to ensure both were processed once the forwarder is initialized.